### PR TITLE
fix: preserve zero-valued internal destination points

### DIFF
--- a/src/bounds/tests/test_internal_destinations.py
+++ b/src/bounds/tests/test_internal_destinations.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import MagicMock
+
+import pymupdf
+
+from src.crop.scale_cropper.internal_destinations import InternalDestinationResolver
+
+
+class InternalDestinationResolverTests(unittest.TestCase):
+    def test_resolve_point_stops_on_explicit_zero_point(self) -> None:
+        resolver = InternalDestinationResolver(MagicMock(), page_count=1)
+        expected = pymupdf.Point(0.0, 0.0)
+
+        resolver._point_from_explicit_to = MagicMock(return_value=expected)
+        resolver._parse_zoom_triplet_point = MagicMock()
+        resolver._handle_fit_destination = MagicMock()
+        resolver._point_from_outline_xref_dest = MagicMock()
+
+        point = resolver._resolve_point({}, 0)
+
+        self.assertEqual(point, expected)
+        resolver._parse_zoom_triplet_point.assert_not_called()
+        resolver._handle_fit_destination.assert_not_called()
+        resolver._point_from_outline_xref_dest.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/crop/scale_cropper/internal_destinations.py
+++ b/src/crop/scale_cropper/internal_destinations.py
@@ -106,12 +106,17 @@ class InternalDestinationResolver:
     def _resolve_point(
         self, link: dict[str, Any], dest_page: int
     ) -> Optional[pymupdf.Point]:
-        return (
-            self._point_from_explicit_to(link)
-            or self._parse_zoom_triplet_point(link)
-            or self._handle_fit_destination(link)
-            or self._point_from_outline_xref_dest(link, dest_page)
+        resolvers = (
+            lambda: self._point_from_explicit_to(link),
+            lambda: self._parse_zoom_triplet_point(link),
+            lambda: self._handle_fit_destination(link),
+            lambda: self._point_from_outline_xref_dest(link, dest_page),
         )
+        for resolve in resolvers:
+            point = resolve()
+            if point is not None:
+                return point
+        return None
 
     def _point_from_explicit_to(self, link: dict[str, Any]) -> Optional[pymupdf.Point]:
         """


### PR DESCRIPTION
## Summary
Fix a regression in `InternalDestinationResolver._resolve_point()` where valid destination points such as `pymupdf.Point(0, 0)` were treated as falsey and caused fallback resolvers to run.

## Changes
- replace the `or` chain in `_resolve_point()` with explicit `is not None` checks
- add a regression test covering the `(0, 0)` case

## Validation
- `pdm run tests`

Fixes #16